### PR TITLE
Issue/39 - Fix Crash When Requesting Permission

### DIFF
--- a/android/src/main/java/notification/listener/service/NotificationListenerServicePlugin.java
+++ b/android/src/main/java/notification/listener/service/NotificationListenerServicePlugin.java
@@ -64,7 +64,6 @@ public class NotificationListenerServicePlugin implements FlutterPlugin, Activit
             Intent intent = new Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS);
             try {
                 mActivity.startActivityForResult(intent, REQUEST_CODE_FOR_NOTIFICATIONS);
-                result.success(null);
             } catch (ActivityNotFoundException e) {
                 Log.e("NotificationPlugin", "ActivityNotFoundException: " + e.getMessage());
                 result.error("ACTIVITY_NOT_FOUND", "No activity found to handle notification listener settings", null);
@@ -156,8 +155,10 @@ public class NotificationListenerServicePlugin implements FlutterPlugin, Activit
             } else {
                 pendingResult.success(false);
             }
+            pendingResult.success(false);
             return true;
         }
+        pendingResult.success(false);
         return false;
     }
 }

--- a/android/src/main/java/notification/listener/service/NotificationListenerServicePlugin.java
+++ b/android/src/main/java/notification/listener/service/NotificationListenerServicePlugin.java
@@ -147,26 +147,17 @@ public class NotificationListenerServicePlugin implements FlutterPlugin, Activit
 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
-        bool isReplied = false;
         if (requestCode == REQUEST_CODE_FOR_NOTIFICATIONS) {
             if (resultCode == Activity.RESULT_OK) {
-                isReplied = true;
                 pendingResult.success(true);
             } else if (resultCode == Activity.RESULT_CANCELED) {
-                isReplied = true;
                 pendingResult.success(isPermissionGranted(context));
             } else {
-                isReplied = true;
-                pendingResult.success(false);
-            }
-            if (!isReplied) {
                 pendingResult.success(false);
             }
             return true;
         }
-        if (!isReplied) {
-            pendingResult.success(false);
-        }
+        pendingResult.success(false);
         return false;
     }
 }

--- a/android/src/main/java/notification/listener/service/NotificationListenerServicePlugin.java
+++ b/android/src/main/java/notification/listener/service/NotificationListenerServicePlugin.java
@@ -147,18 +147,26 @@ public class NotificationListenerServicePlugin implements FlutterPlugin, Activit
 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
+        bool isReplied = false;
         if (requestCode == REQUEST_CODE_FOR_NOTIFICATIONS) {
             if (resultCode == Activity.RESULT_OK) {
+                isReplied = true;
                 pendingResult.success(true);
             } else if (resultCode == Activity.RESULT_CANCELED) {
+                isReplied = true;
                 pendingResult.success(isPermissionGranted(context));
             } else {
+                isReplied = true;
                 pendingResult.success(false);
             }
-            pendingResult.success(false);
+            if (!isReplied) {
+                pendingResult.success(false);
+            }
             return true;
         }
-        pendingResult.success(false);
+        if (!isReplied) {
+            pendingResult.success(false);
+        }
         return false;
     }
 }

--- a/android/src/main/java/notification/listener/service/NotificationListenerServicePlugin.java
+++ b/android/src/main/java/notification/listener/service/NotificationListenerServicePlugin.java
@@ -157,7 +157,6 @@ public class NotificationListenerServicePlugin implements FlutterPlugin, Activit
             }
             return true;
         }
-        pendingResult.success(false);
         return false;
     }
 }

--- a/lib/notification_listener_service.dart
+++ b/lib/notification_listener_service.dart
@@ -27,7 +27,7 @@ class NotificationListenerService {
 
   /// request notification permission
   /// it will open the notification settings page and return `true` once the permission granted.
-  static Future<bool> requestPermission() async {
+  static Future<bool?> requestPermission() async {
     try {
       return await methodeChannel.invokeMethod('requestPermission');
     } on PlatformException catch (error) {
@@ -37,7 +37,7 @@ class NotificationListenerService {
   }
 
   /// check if notification permission is enebaled
-  static Future<bool> isPermissionGranted() async {
+  static Future<bool?> isPermissionGranted() async {
     try {
       return await methodeChannel.invokeMethod('isPermissionGranted');
     } on PlatformException catch (error) {

--- a/lib/notification_listener_service.dart
+++ b/lib/notification_listener_service.dart
@@ -27,7 +27,7 @@ class NotificationListenerService {
 
   /// request notification permission
   /// it will open the notification settings page and return `true` once the permission granted.
-  static Future<bool?> requestPermission() async {
+  static Future<bool> requestPermission() async {
     try {
       return await methodeChannel.invokeMethod('requestPermission');
     } on PlatformException catch (error) {
@@ -37,7 +37,7 @@ class NotificationListenerService {
   }
 
   /// check if notification permission is enebaled
-  static Future<bool?> isPermissionGranted() async {
+  static Future<bool> isPermissionGranted() async {
     try {
       return await methodeChannel.invokeMethod('isPermissionGranted');
     } on PlatformException catch (error) {


### PR DESCRIPTION
- Fixed the following issue where null was returned for `requestPermission` method call which was causing `TypeError`.
- Have tested with the `example` app now it seems to be working fine.
- https://github.com/X-SLAYER/notification_listener_service/issues/39